### PR TITLE
[parser] make function support params

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1291,6 +1291,7 @@ impl fmt::Display for FunctionArg {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Function {
     pub name: ObjectName,
+    pub params: Vec<Value>,
     pub args: Vec<FunctionArg>,
     pub over: Option<WindowSpec>,
     // aggregate functions may specify eg `COUNT(DISTINCT x)`
@@ -1299,13 +1300,17 @@ pub struct Function {
 
 impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name)?;
+        if !self.params.is_empty() {
+            write!(f, "({})", display_comma_separated(&self.params))?;
+        }
         write!(
             f,
-            "{}({}{})",
-            self.name,
+            "({}{})",
             if self.distinct { "DISTINCT " } else { "" },
             display_comma_separated(&self.args),
         )?;
+
         if let Some(o) = &self.over {
             write!(f, " OVER ({})", o)?;
         }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1009,16 +1009,16 @@ impl fmt::Display for Statement {
                 }
                 match hive_distribution {
                     HiveDistributionStyle::PARTITIONED { columns } => {
-                        write!(f, " PARTITIONED BY ({})", display_comma_separated(&columns))?;
+                        write!(f, " PARTITIONED BY ({})", display_comma_separated(columns))?;
                     }
                     HiveDistributionStyle::CLUSTERED {
                         columns,
                         sorted_by,
                         num_buckets,
                     } => {
-                        write!(f, " CLUSTERED BY ({})", display_comma_separated(&columns))?;
+                        write!(f, " CLUSTERED BY ({})", display_comma_separated(columns))?;
                         if !sorted_by.is_empty() {
-                            write!(f, " SORTED BY ({})", display_comma_separated(&sorted_by))?;
+                            write!(f, " SORTED BY ({})", display_comma_separated(sorted_by))?;
                         }
                         if *num_buckets > 0 {
                             write!(f, " INTO {} BUCKETS", num_buckets)?;
@@ -1032,8 +1032,8 @@ impl fmt::Display for Statement {
                         write!(
                             f,
                             " SKEWED BY ({})) ON ({})",
-                            display_comma_separated(&columns),
-                            display_comma_separated(&on)
+                            display_comma_separated(columns),
+                            display_comma_separated(on)
                         )?;
                         if *stored_as_directories {
                             write!(f, " STORED AS DIRECTORIES")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -102,7 +102,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a SQL statement and produce an Abstract Syntax Tree (AST)
     pub fn parse_sql(dialect: &dyn Dialect, sql: &str) -> Result<Vec<Statement>, ParserError> {
-        let mut tokenizer = Tokenizer::new(dialect, &sql);
+        let mut tokenizer = Tokenizer::new(dialect, sql);
         let tokens = tokenizer.tokenize()?;
         let mut parser = Parser::new(tokens, dialect);
         let mut stmts = Vec::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -462,7 +462,7 @@ impl<'a> Parser<'a> {
 
         let params = self
             .maybe_parse(|parser| parser.parse_optional_params())
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         let distinct = self.parse_all_or_distinct()?;
         let args = self.parse_optional_args()?;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -64,7 +64,7 @@ impl TestedDialects {
     }
 
     pub fn parse_sql_statements(&self, sql: &str) -> Result<Vec<Statement>, ParserError> {
-        self.one_of_identical_results(|dialect| Parser::parse_sql(dialect, &sql))
+        self.one_of_identical_results(|dialect| Parser::parse_sql(dialect, sql))
         // To fail the `ensure_multiple_dialects_are_tested` test:
         // Parser::parse_sql(&**self.dialects.first().unwrap(), sql)
     }
@@ -75,11 +75,11 @@ impl TestedDialects {
     /// tree as parsing `canonical`, and that serializing it back to string
     /// results in the `canonical` representation.
     pub fn one_statement_parses_to(&self, sql: &str, canonical: &str) -> Statement {
-        let mut statements = self.parse_sql_statements(&sql).unwrap();
+        let mut statements = self.parse_sql_statements(sql).unwrap();
         assert_eq!(statements.len(), 1);
 
         if !canonical.is_empty() && sql != canonical {
-            assert_eq!(self.parse_sql_statements(&canonical).unwrap(), statements);
+            assert_eq!(self.parse_sql_statements(canonical).unwrap(), statements);
         }
 
         let only_statement = statements.pop().unwrap();

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -63,22 +63,22 @@ fn parse_insert_values() {
         sql,
         "public.customer",
         &["id".to_string(), "name".to_string(), "active".to_string()],
-        &vec![],
+        &[],
         "",
     );
 
     let sql = "INSERT INTO public.customer VALUES";
-    check_one(sql, "public.customer", &[], &vec![], "");
+    check_one(sql, "public.customer", &[], &[], "");
 
     let sql = "INSERT INTO public.customer FORMAT TSV";
-    check_one(sql, "public.customer", &[], &vec![], "TSV");
+    check_one(sql, "public.customer", &[], &[], "TSV");
 
     let sql = "INSERT INTO public.customer (id, name, active) FORMAT TSV";
     check_one(
         sql,
         "public.customer",
         &["id".to_string(), "name".to_string(), "active".to_string()],
-        &vec![],
+        &[],
         "TSV",
     );
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -137,7 +137,7 @@ fn parse_insert_sqlite() {
     let dialect = SQLiteDialect {};
 
     let check = |sql: &str, expected_action: Option<SqliteOnConflict>| match Parser::parse_sql(
-        &dialect, &sql,
+        &dialect, sql,
     )
     .unwrap()
     .pop()
@@ -375,7 +375,7 @@ fn parse_column_aliases() {
     }
 
     // alias without AS is parsed correctly:
-    one_statement_parses_to("SELECT a.col + 1 newname FROM foo AS a", &sql);
+    one_statement_parses_to("SELECT a.col + 1 newname FROM foo AS a", sql);
 }
 
 #[test]
@@ -2757,7 +2757,7 @@ fn parse_multiple_statements() {
         let res = parse_sql_statements(&(sql1.to_owned() + ";" + sql2_kw + sql2_rest));
         assert_eq!(
             vec![
-                one_statement_parses_to(&sql1, ""),
+                one_statement_parses_to(sql1, ""),
                 one_statement_parses_to(&(sql2_kw.to_owned() + sql2_rest), ""),
             ],
             res.unwrap()

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -409,6 +409,7 @@ fn parse_select_count_wildcard() {
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("COUNT")]),
+            params: vec![],
             args: vec![FunctionArg::Unnamed(Expr::Wildcard)],
             over: None,
             distinct: false,
@@ -424,6 +425,7 @@ fn parse_select_count_distinct() {
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("COUNT")]),
+            params: vec![],
             args: vec![FunctionArg::Unnamed(Expr::UnaryOp {
                 op: UnaryOperator::Plus,
                 expr: Box::new(Expr::Identifier(Ident::new("x"))),
@@ -444,6 +446,25 @@ fn parse_select_count_distinct() {
     assert_eq!(
         ParserError::ParserError("Cannot specify both ALL and DISTINCT".to_string()),
         res.unwrap_err()
+    );
+}
+
+#[test]
+fn parse_function_with_params() {
+    let sql = "SELECT funnel(3600)(x, y) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("funnel")]),
+            params: vec![Value::Number("3600".parse().unwrap(), false)],
+            args: vec![
+                FunctionArg::Unnamed(Expr::Identifier(Ident::new("x"))),
+                FunctionArg::Unnamed(Expr::Identifier(Ident::new("y")))
+            ],
+            over: None,
+            distinct: false,
+        }),
+        expr_from_projection(only(&select.projection))
     );
 }
 
@@ -1018,6 +1039,7 @@ fn parse_select_having() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Function(Function {
                 name: ObjectName(vec![Ident::new("COUNT")]),
+                params: vec![],
                 args: vec![FunctionArg::Unnamed(Expr::Wildcard)],
                 over: None,
                 distinct: false,
@@ -1781,6 +1803,7 @@ fn parse_scalar_function_in_projection() {
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("sqrt")]),
+            params: vec![],
             args: vec![FunctionArg::Unnamed(Expr::Identifier(Ident::new("id")))],
             over: None,
             distinct: false,
@@ -1824,6 +1847,7 @@ fn parse_named_argument_function() {
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("FUN")]),
+            params: vec![],
             args: vec![
                 FunctionArg::Named {
                     name: Ident::new("a"),
@@ -1858,6 +1882,7 @@ fn parse_window_functions() {
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("row_number")]),
+            params: vec![],
             args: vec![],
             over: Some(WindowSpec {
                 partition_by: vec![],
@@ -2091,6 +2116,7 @@ fn parse_table_function() {
         TableFactor::TableFunction { expr, alias } => {
             let expected_expr = Expr::Function(Function {
                 name: ObjectName(vec![Ident::new("FUN")]),
+                params: vec![],
                 args: vec![FunctionArg::Unnamed(Expr::Value(
                     Value::SingleQuotedString("1".to_owned()),
                 ))],
@@ -2149,6 +2175,7 @@ fn parse_delimited_identifiers() {
     assert_eq!(
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::with_quote('"', "myfun")]),
+            params: vec![],
             args: vec![],
             over: None,
             distinct: false,

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -38,7 +38,7 @@ fn test_snowflake_create_table() {
 fn test_snowflake_single_line_tokenize() {
     let sql = "CREATE TABLE# this is a comment \ntable_1";
     let dialect = SnowflakeDialect {};
-    let mut tokenizer = Tokenizer::new(&dialect, &sql);
+    let mut tokenizer = Tokenizer::new(&dialect, sql);
     let tokens = tokenizer.tokenize().unwrap();
 
     let expected = vec![
@@ -55,7 +55,7 @@ fn test_snowflake_single_line_tokenize() {
     assert_eq!(expected, tokens);
 
     let sql = "CREATE TABLE// this is a comment \ntable_1";
-    let mut tokenizer = Tokenizer::new(&dialect, &sql);
+    let mut tokenizer = Tokenizer::new(&dialect, sql);
     let tokens = tokenizer.tokenize().unwrap();
 
     let expected = vec![


### PR DESCRIPTION
- Make function support params, like :  `funnel(3600)(x, y)`
- New style of clippy