### PR TITLE
support snowflake variant/array/object data element access

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -293,6 +293,8 @@ impl fmt::Display for Expr {
                     match k {
                         k @ Value::Number(_, _) => write!(f, "[{}]", k)?,
                         Value::SingleQuotedString(s) => write!(f, "[\"{}\"]", s)?,
+                        Value::ColonString(s) => write!(f, ":{}", s)?,
+                        Value::PeriodString(s) => write!(f, ".{}", s)?,
                         _ => write!(f, "[{}]", k)?,
                     }
                 }

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -36,6 +36,10 @@ pub enum Value {
     NationalStringLiteral(String),
     /// X'hex value'
     HexStringLiteral(String),
+    /// :string value
+    ColonString(String),
+    /// .string value
+    PeriodString(String),
 
     DoubleQuotedString(String),
     /// Boolean value true or false
@@ -75,6 +79,8 @@ impl Value {
             Value::NationalStringLiteral(v) => Value::NationalStringLiteral(format!("-{}", v)),
             Value::HexStringLiteral(v) => Value::HexStringLiteral(format!("-{}", v)),
             Value::DoubleQuotedString(v) => Value::DoubleQuotedString(format!("-{}", v)),
+            Value::ColonString(v) => Value::ColonString(format!("-{}", v)),
+            Value::PeriodString(v) => Value::PeriodString(format!("-{}", v)),
             Value::Boolean(v) => Value::Boolean(v),
             Value::Interval {
                 value,
@@ -102,6 +108,8 @@ impl fmt::Display for Value {
             Value::SingleQuotedString(v) => write!(f, "'{}'", escape_single_quote_string(v)),
             Value::NationalStringLiteral(v) => write!(f, "N'{}'", v),
             Value::HexStringLiteral(v) => write!(f, "X'{}'", v),
+            Value::ColonString(v) => write!(f, ":{}", v),
+            Value::PeriodString(v) => write!(f, ".{}", v),
             Value::Boolean(v) => write!(f, "{}", v),
             Value::Interval {
                 value,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3222,10 +3222,10 @@ fn parse_scalar_subqueries() {
     assert_matches!(
         verified_expr(sql),
         Expr::BinaryOp {
-        op: BinaryOperator::Plus, ..
-        //left: box Subquery { .. },
-        //right: box Subquery { .. },
-    }
+            op: BinaryOperator::Plus,
+            .. //left: box Subquery { .. },
+               //right: box Subquery { .. },
+        }
     );
 }
 


### PR DESCRIPTION
support snowflake access  element in `variant`, `array`, `object`

for example:
```sql
select obj["a"]["b"] from test;
select obj:a.b from test;
select obj:a["b"] from test;
select array[0][0] from test;
```