### PR TITLE
fix: fix stream values parse

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -258,6 +258,18 @@ impl Default for QueryOffset {
     }
 }
 
+impl QueryOffset {
+    /// Since sqlparser need work in non std env, we use this replace with std order
+    pub fn less_than(&self, other: &QueryOffset) -> bool {
+        match (self, other) {
+            (QueryOffset::Normal(v1), QueryOffset::Normal(v2)) => v1 < v2,
+            (QueryOffset::Normal(_), QueryOffset::EOF) => true,
+            (QueryOffset::EOF, QueryOffset::Normal(_)) => false,
+            (QueryOffset::EOF, QueryOffset::EOF) => false,
+        }
+    }
+}
+
 impl fmt::Display for QueryOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -152,17 +152,17 @@ fn parse_stream_values_insert() {
             expected_format: "".to_string(),
         },
         TestCase {
-            sql: "INSERT INTO t values (1,2,3), (4,5,6) ;".to_string(),
+            sql: "INSERT INTO t values ;".to_string(),
             expected_table_name: "t".to_string(),
             expected_columns: vec![],
-            expected_values: " (1,2,3), (4,5,6) ".to_string(),
+            expected_values: " ".to_string(),
             expected_format: "".to_string(),
         },
         TestCase {
-            sql: "INSERT INTO t(c1,c2) values (1,2) on duplicate key update c3 = 10;".to_string(),
+            sql: "insert into t values(now(), now(), today(), today());".to_string(),
             expected_table_name: "t".to_string(),
-            expected_columns: vec![String::from("c1"), String::from("c2")],
-            expected_values: " (1,2) ".to_string(),
+            expected_columns: vec![],
+            expected_values: "(now(), now(), today(), today())".to_string(),
             expected_format: "".to_string(),
         },
         TestCase {
@@ -222,7 +222,6 @@ fn parse_stream_values_insert() {
                 }
                 _ => unreachable!(),
             }
-            print!("{:?}", &sql[20..29]);
         });
     }
 }
@@ -234,20 +233,14 @@ fn parse_insert_stream_values_invalid() {
         expected_err: ParserError,
     }
 
-    let tests = vec![
+    let tests: Vec<TestCase> = vec![
         TestCase {
-            sql: "INSERT into t values 1,2,3) ;".to_string(),
-            expected_err: ParserError::ParserError("Expected (, found: 1".to_string()),
+            sql: "INSERT into t values 1,2,3) on".to_string(),
+            expected_err: ParserError::ParserError("Expected DUPLICATE, found: EOF".to_string()),
         },
         TestCase {
-            sql: "INSERT into t values (1,2,3 ;".to_string(),
-            expected_err: ParserError::ParserError("Expected ), found: EOF".to_string()),
-        },
-        TestCase {
-            sql: "INSERT into t values (1,2,3) (4,5,6) ;".to_string(),
-            expected_err: ParserError::ParserError(
-                "VALUES end is not correct, values end: (, idx: 16".to_string(),
-            ),
+            sql: "INSERT into t values 1,2,3) on;".to_string(),
+            expected_err: ParserError::ParserError("Expected DUPLICATE, found: ;".to_string()),
         },
     ];
 


### PR DESCRIPTION
1. Skip to the end of values directly without checks.
2. Assert to ensure the start is always less than the end of `StreamValues`.