### PR TITLE
feat: distinguish postgresql style cast

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -14,7 +14,7 @@
 //! (commonly referred to as Data Definition Language, or DDL)
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::ToString, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 #[cfg(feature = "serde")]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -201,6 +201,7 @@ pub enum Expr {
     Cast {
         expr: Box<Expr>,
         data_type: DataType,
+        pg_style: bool,
     },
     /// TRY_CAST an expression to a different data type e.g. `TRY_CAST(foo AS VARCHAR(123))`
     //  this differs from CAST in the choice of how to implement invalid conversions
@@ -346,7 +347,17 @@ impl fmt::Display for Expr {
                     write!(f, "{} {}", op, expr)
                 }
             }
-            Expr::Cast { expr, data_type } => write!(f, "CAST({} AS {})", expr, data_type),
+            Expr::Cast {
+                expr,
+                data_type,
+                pg_style,
+            } => {
+                if *pg_style {
+                    write!(f, "{}::{}", expr, data_type)
+                } else {
+                    write!(f, "CAST({} AS {})", expr, data_type)
+                }
+            }
             Expr::TryCast { expr, data_type } => write!(f, "TRY_CAST({} AS {})", expr, data_type),
             Expr::Extract { field, expr } => write!(f, "EXTRACT({} FROM {})", field, expr),
             Expr::Collate { expr, collation } => write!(f, "{} COLLATE {}", expr, collation),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -731,6 +731,7 @@ impl<'a> Parser<'a> {
         Ok(Expr::Cast {
             expr: Box::new(expr),
             data_type,
+            pg_style: false,
         })
     }
 
@@ -1215,6 +1216,7 @@ impl<'a> Parser<'a> {
         Ok(Expr::Cast {
             expr: Box::new(expr),
             data_type: self.parse_data_type()?,
+            pg_style: true,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1480,7 +1480,8 @@ fn parse_cast() {
     assert_eq!(
         &Expr::Cast {
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
-            data_type: DataType::BigInt(None)
+            data_type: DataType::BigInt(None),
+            pg_style: false,
         },
         expr_from_projection(only(&select.projection))
     );
@@ -1490,7 +1491,8 @@ fn parse_cast() {
     assert_eq!(
         &Expr::Cast {
             expr: Box::new(Expr::Identifier(Ident::new("id"))),
-            data_type: DataType::TinyInt(None)
+            data_type: DataType::TinyInt(None),
+            pg_style: false,
         },
         expr_from_projection(only(&select.projection))
     );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -130,9 +130,7 @@ fn parse_create_table_with_defaults() {
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
-                                option: ColumnOption::Default(
-                                    pg().verified_expr("CAST(now() AS TEXT)")
-                                )
+                                option: ColumnOption::Default(pg().verified_expr("now()::TEXT"))
                             },
                             ColumnOptionDef {
                                 name: None,
@@ -205,20 +203,23 @@ fn parse_create_table_from_pg_dump() {
             release_year public.year,
             active integer
         )";
-    pg().one_statement_parses_to(sql, "CREATE TABLE public.customer (\
-            customer_id INT DEFAULT nextval(CAST('public.customer_customer_id_seq' AS REGCLASS)) NOT NULL, \
+    pg().one_statement_parses_to(
+        sql,
+        "CREATE TABLE public.customer (\
+            customer_id INT DEFAULT nextval('public.customer_customer_id_seq'::REGCLASS) NOT NULL, \
             store_id SMALLINT NOT NULL, \
             first_name CHARACTER VARYING(45) NOT NULL, \
             last_name CHARACTER VARYING(45) NOT NULL, \
             info TEXT[], \
             address_id SMALLINT NOT NULL, \
             activebool BOOLEAN DEFAULT true NOT NULL, \
-            create_date DATE DEFAULT CAST(now() AS DATE) NOT NULL, \
-            create_date1 DATE DEFAULT CAST(CAST('now' AS TEXT) AS DATE) NOT NULL, \
+            create_date DATE DEFAULT now()::DATE NOT NULL, \
+            create_date1 DATE DEFAULT 'now'::TEXT::DATE NOT NULL, \
             last_update TIMESTAMP DEFAULT now(), \
             release_year public.year, \
             active INT\
-        )");
+        )",
+    );
 }
 
 #[test]
@@ -751,6 +752,31 @@ fn test_transaction_statement() {
             snapshot: None,
             session: true
         }
+    );
+}
+
+#[test]
+fn parse_cast() {
+    let sql = "SELECT id::BIGINT FROM customer";
+    let select = pg_and_generic().verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("id"))),
+            data_type: DataType::BigInt(None),
+            pg_style: true,
+        },
+        expr_from_projection(only(&select.projection))
+    );
+
+    let sql = "SELECT id::TINYINT FROM customer";
+    let select = pg_and_generic().verified_only_select(sql);
+    assert_eq!(
+        &Expr::Cast {
+            expr: Box::new(Expr::Identifier(Ident::new("id"))),
+            data_type: DataType::TinyInt(None),
+            pg_style: true,
+        },
+        expr_from_projection(only(&select.projection))
     );
 }
 


### PR DESCRIPTION
Distinguish between PostgreSQL-style cast and normal cast

```sql
select cast(a as Int8) from test;
select a::Int8 from test;
```