### PR TITLE
Support select expr as `alias_name`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2377,6 +2377,7 @@ impl<'a> Parser<'a> {
             //    ignore the <separator> and treat the multiple strings as
             //    a single <literal>."
             Token::SingleQuotedString(s) => Ok(Some(Ident::with_quote('\'', s))),
+            Token::BackQuotedString(s) => Ok(Some(Ident::with_quote('`', s))),
             not_an_ident => {
                 if after_as {
                     return self.expected("an identifier after AS", not_an_ident);


### PR DESCRIPTION
Link to issue 
https://github.com/datafuse-extras/sqlparser-rs/issues/26#issue-1202923013

> ```sql
> SELECT TRUE as `_`  FROM `t1` WHERE 1 <> 1 LIMIT 0 ;
> ERROR 1105 (HY000): Code: 1005, displayText = sql parser error: Expected an identifier after AS, found: `_`.
> ```
> 
> But in MySQL:
> 
> ```sql
> mysql> create table t1(id int);
> Query OK, 0 rows affected (0.03 sec)
> 
> mysql> SELECT TRUE as `_`  FROM `t1` WHERE 1 <> 1 LIMIT 0 ;
> Empty set (0.00 sec)
> ```
> 
> And also, the metabase send this query to DB server `SELECT TRUE AS `_`FROM`t` WHERE 1 <> 1 LIMIT 0`

