### PR TITLE
Support Token DoubleQuoted

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -558,7 +558,10 @@ impl<'a> Parser<'a> {
                 self.prev_token();
                 Ok(Expr::Value(self.parse_value()?))
             }
-
+            Token::DoubleQuotedString(_) if dialect_of!(self is MySqlDialect) => {
+                self.prev_token();
+                Ok(Expr::Value(self.parse_value()?))
+            }
             Token::LParen => {
                 let expr =
                     if self.parse_keyword(Keyword::SELECT) || self.parse_keyword(Keyword::WITH) {
@@ -2265,6 +2268,9 @@ impl<'a> Parser<'a> {
                 Err(e) => parser_err!(format!("Could not parse '{}' as number: {}", n, e)),
             },
             Token::SingleQuotedString(ref s) => Ok(Value::SingleQuotedString(s.to_string())),
+            Token::DoubleQuotedString(ref s) if dialect_of!(self is MySqlDialect) => {
+                Ok(Value::DoubleQuotedString(s.to_string()))
+            }
             Token::NationalStringLiteral(ref s) => Ok(Value::NationalStringLiteral(s.to_string())),
             Token::HexStringLiteral(ref s) => Ok(Value::HexStringLiteral(s.to_string())),
             unexpected => self.expected("a value", unexpected),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -210,7 +210,6 @@ fn parse_stream_values_insert() {
                                     }
                                     _ => unreachable!(),
                                 };
-
                                 assert_eq!(values, expected_values)
                             }
                             _ => unreachable!(),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -293,6 +293,24 @@ fn parse_simple_insert() {
 }
 
 #[test]
+fn parse_double_quoted_insert() {
+    let sql_double_quoted =
+        r#"INSERT INTO tasks (title, priority) VALUES ("Test S\"o\"m'e' In'se\"rt`s\"", 1)"#;
+    let mut double_statements = mysql().parse_sql_statements(sql_double_quoted).unwrap();
+    assert_eq!(double_statements.len(), 1);
+    let double_statement = double_statements.pop().unwrap();
+    match double_statement {
+        Statement::Insert { source, .. } => {
+            assert_eq!(
+                source.unwrap().body.to_string(),
+                "VALUES (\"Test S\"o\"m'e' In'se\"rt`s\"\", 1)"
+            )
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_insert_with_on_duplicate_update() {
     let sql = "INSERT INTO permission_groups (name, description, perm_create, perm_read, perm_update, perm_delete) VALUES ('accounting_manager', 'Some description about the group', true, true, true, true) ON DUPLICATE KEY UPDATE description = VALUES(description), perm_create = VALUES(perm_create), perm_read = VALUES(perm_read), perm_update = VALUES(perm_update), perm_delete = VALUES(perm_delete)";
 


### PR DESCRIPTION
Link to #30

**Summary**

MySQL support insert value with double quoted like this : 

```SQL
insert into db.t values ("valuess");
```

but now, next_token not impl double quoted case. '`"`' just a char.
