### PR TITLE
fix bug for doublequoted

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2302,6 +2302,7 @@ impl<'a> Parser<'a> {
         match self.next_token() {
             Token::Word(Word { value, keyword, .. }) if keyword == Keyword::NoKeyword => Ok(value),
             Token::SingleQuotedString(s) => Ok(s),
+            Token::DoubleQuotedString(s) if dialect_of!(self is MySqlDialect) => Ok(s),
             unexpected => self.expected("literal string", unexpected),
         }
     }
@@ -2313,6 +2314,9 @@ impl<'a> Parser<'a> {
                 Ok(Value::SingleQuotedString(value))
             }
             Token::SingleQuotedString(s) => Ok(Value::SingleQuotedString(s)),
+            Token::DoubleQuotedString(s) if dialect_of!(self is MySqlDialect) => {
+                Ok(Value::DoubleQuotedString(s))
+            }
             #[cfg(not(feature = "bigdecimal"))]
             Token::Number(s, _) => Ok(Value::Number(s, false)),
             #[cfg(feature = "bigdecimal")]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -333,7 +333,7 @@ fn parse_simple_insert() {
 }
 
 #[test]
-fn parse_double_quoted_insert() {
+fn parse_double_quoted() {
     let sql_double_quoted =
         r#"INSERT INTO tasks (title, priority) VALUES ("Test S\"o\"m'e' In'se\"rt`s\"", 1)"#;
     let mut double_statements = mysql().parse_sql_statements(sql_double_quoted).unwrap();
@@ -348,6 +348,20 @@ fn parse_double_quoted_insert() {
         }
         _ => unreachable!(),
     }
+
+    let select_sql = r#"SELECT obj["c"][0] FROM t4"#;
+    mysql().verified_stmt(select_sql);
+
+    let sql = r#"SELECT * FROM customers WHERE name LIKE "%a" IS NULL"#;
+    let select = mysql().verified_only_select(sql);
+    assert_eq!(
+        Expr::IsNull(Box::new(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier(Ident::new("name"))),
+            op: BinaryOperator::Like,
+            right: Box::new(Expr::Value(Value::DoubleQuotedString("%a".to_string()))),
+        })),
+        select.selection.unwrap()
+    );
 }
 
 #[test]


### PR DESCRIPTION
**Summary**

https://github.com/datafuselabs/databend/runs/6046101935?check_suite_focus=true  03_0018_insert_into_variant

Add some case

```SQL
select * from t where col like "x"
--and
SELECT obj["c"][0] FROM t4
```
