### PR TITLE
fix(function): map access support array and function

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1239,7 +1239,11 @@ impl<'a> Parser<'a> {
     pub fn parse_map_access(&mut self, expr: Expr) -> Result<Expr, ParserError> {
         let key_parts = self.parse_map_keys()?;
         match expr {
-            e @ Expr::Identifier(_) | e @ Expr::CompoundIdentifier(_) => Ok(Expr::MapAccess {
+            e @ Expr::Identifier(_)
+            | e @ Expr::CompoundIdentifier(_)
+            | e @ Expr::Array(_)
+            | e @ Expr::Nested(_)
+            | e @ Expr::Function(_) => Ok(Expr::MapAccess {
                 column: Box::new(e),
                 keys: key_parts,
             }),
@@ -2600,6 +2604,9 @@ impl<'a> Parser<'a> {
         right: &Token,
     ) -> Result<Vec<Expr>, ParserError> {
         if self.consume_token(left) {
+            if self.consume_token(right) {
+                return Ok(vec![]);
+            }
             let exprs = self.parse_comma_separated(Parser::parse_expr)?;
             self.expect_token(right)?;
             Ok(exprs)

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -331,7 +331,7 @@ fn parse_simple_insert() {
         _ => unreachable!(),
     }
 
-    let sql = r"INSERT INTO array_test (nums) VALUES ([1, 2, 3]), ([4, 5, 6])";
+    let sql = r"INSERT INTO array_test (nums) VALUES ([]), ([1, 2, 3]), ([4, 5, 6])";
     match mysql().verified_stmt(sql) {
         Statement::Insert {
             table_name,
@@ -348,6 +348,7 @@ fn parse_simple_insert() {
                     with: None,
                     body: SetExpr::Values(Values(
                         vec![
+                            vec![Expr::Array(vec![]),],
                             vec![Expr::Array(vec![
                                 Expr::Value(number("1")),
                                 Expr::Value(number("2")),


### PR DESCRIPTION
map access support array and function:

```sql
select [0,1,2,3][0];
select ([0,1,2,3])[0];
select parse_json('[0,1,2,3]')[0];
```
support parse empty array
```sql
select [];
```

fix https://github.com/datafuselabs/databend/issues/5305
