### PR TITLE
fix map access with and

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1350,7 +1350,7 @@ impl<'a> Parser<'a> {
             Token::DoubleColon => Ok(50),
             Token::ExclamationMark => Ok(50),
             Token::LBracket => Ok(10),
-            Token::Colon => Ok(10),
+            Token::Colon => Ok(11),
             _ => Ok(0),
         }
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -815,6 +815,14 @@ fn parse_escaped_single_quote_string_predicate() {
 }
 
 #[test]
+fn parse_select_where_map_access() {
+    let sql = "SELECT * FROM test WHERE id = 1 AND labels:email = 'abc@test.com'";
+    let _ast = verified_only_select(sql);
+    let sql = "SELECT * FROM test WHERE id = 1 OR labels:email = 'abc@test.com'";
+    let _ast = verified_only_select(sql);
+}
+
+#[test]
 fn parse_number() {
     let expr = verified_expr("1.0");
 


### PR DESCRIPTION
Fix the wrong priority relationship between `map access` and `and`

```sql
SELECT * FROM test WHERE id = 1 and labels:email = 'abc@test.com';
```
[#databend 6590](https://github.com/datafuselabs/databend/issues/6590)